### PR TITLE
disable pagination to better mimic old backend API

### DIFF
--- a/tracksrv/tracksrv/settings.py
+++ b/tracksrv/tracksrv/settings.py
@@ -83,8 +83,8 @@ TEMPLATES = [
 ]
 
 REST_FRAMEWORK = {
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 10
+#    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+#    'PAGE_SIZE': 10,
 }
 
 WSGI_APPLICATION = 'tracksrv.wsgi.application'


### PR DESCRIPTION
The old backend did not use pagination. Switch off pagination for now, to get closer to the original backend.